### PR TITLE
Fix autosave message breaking editor textarea

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -61,6 +61,7 @@ form#dw__editform {
         border-radius: 2px;
         word-wrap: normal;
         text-align: left;
+        width: 100%;
     }
 
     .CodeMirror pre {


### PR DESCRIPTION
See https://forum.dokuwiki.org/d/18017-maintainer-for-codemirror-wanted/29 :

> The "this draft was autosaved" message seems to push the right edge of the edit window to the left rather than being placed on top or below the edit window. (this is especially problematic on a smartphone, I've turned off autosave for now)

Same thing on my install. The width of the textarea is reduced by half as soon as an autosave message appears. The width of CodeMirror's textarea is not defined so it gets pushed. Adding a `width: 100%` like Doku's textarea fixes the problem.